### PR TITLE
Added (maybe fogotten) permissions to hawkeye.*

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,9 +18,11 @@ permissions:
             hawkeye.tpto: true
             hawkeye.rollback: true
             hawkeye.tool: true
+            hawkeye.tool.bind: true
             hawkeye.notify: true
             hawkeye.preview: true
             hawkeye.page: true
+            hawkeye.rebuild: true
     hawkeye.tool.*:
         description: Permission to use the HawkEye tool
         default: false


### PR DESCRIPTION
To use the /he rebuild and /he tool bind commands you need to search the "lost" permissions in the source code...
Also it isn't really a "all permissions" permission when you have to define two extra permissions to get actually all permissions.
Here's the fix. 
