### PR TITLE
Change update checking recommendation to an informational message 

### DIFF
--- a/src/main/java/uk/co/oliwali/HawkEye/HawkEye.java
+++ b/src/main/java/uk/co/oliwali/HawkEye/HawkEye.java
@@ -119,7 +119,7 @@ public class HawkEye extends JavaPlugin {
 
 		//Check if update checking enabled
 		if (!Config.CheckUpdates) {
-			Util.warning("Update checking is disabled, this is not recommended!");
+			Util.info("Update checking is disabled, this is not recommended!");
 			return;
 		}
 


### PR DESCRIPTION
Warnings seem better suited to potential unknown problems as opposed to conscious configuration choices.  

It might even make more sense to log this as a CONFIG entry, but I didn't take the time to analyze how you control your logging levels.
