### PR TITLE
Build fix for Java 7

### DIFF
--- a/src/main/java/uk/co/oliwali/HawkEye/database/JDCConnection.java
+++ b/src/main/java/uk/co/oliwali/HawkEye/database/JDCConnection.java
@@ -17,6 +17,7 @@ import java.sql.Statement;
 import java.sql.Struct;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Executor;
 
 public class JDCConnection implements Connection
 {
@@ -282,6 +283,31 @@ public class JDCConnection implements Connection
 		return conn.unwrap(iface);
 	}
 
+	@Override
+	public int getNetworkTimeout() throws SQLException {
+		return conn.getNetworkTimeout();
+	}
+
+	@Override
+	public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+		conn.setNetworkTimeout(executor, milliseconds);
+	}
+
+	@Override
+	public String getSchema() throws SQLException {
+		return conn.getSchema();
+	}
+
+	@Override
+	public void setSchema(String schema) throws SQLException {
+		conn.setSchema(schema);
+	}
+
+	@Override
+	public void abort(Executor executor) throws SQLException {
+		conn.abort(executor);
+	}
+
 	long getLastUse() {
 		return timestamp;
 	}
@@ -311,5 +337,4 @@ public class JDCConnection implements Connection
 			conn.close();
 		} catch (final SQLException ex) {}
 	}
-
 }


### PR DESCRIPTION
Hello,

This fixes the build for Java 7 by overriding methods that are required to be overridden. This fix works fine for me.
