### PR TITLE
Fix for bugs in items.txt

### DIFF
--- a/HawkEye Interface/interface.php
+++ b/HawkEye Interface/interface.php
@@ -155,7 +155,7 @@
 	foreach($items as $i) {
 		$item = explode(",", $i, 2);
 		if (count($item) < 2) continue;
-		$itemhash[intval($item[0])] = $item[1];
+		if(isset($item[0]) && isset($item[1])) $itemhash[intval($item[0])] = $item[1];
 	}
 	$results = array();
 	


### PR DESCRIPTION
Did not show any results (Loading Bar only), Firebug told me "offset 1 not found in interface.php line 141" (1.0.7d).
This should fix missing Item Descriptions in items.txt
