### PR TITLE
Container Rollback BugFix (Issue #105)

### DIFF
--- a/src/main/java/uk/co/oliwali/HawkEye/entry/ContainerEntry.java
+++ b/src/main/java/uk/co/oliwali/HawkEye/entry/ContainerEntry.java
@@ -1,17 +1,17 @@
 package uk.co.oliwali.HawkEye.entry;
 
-import java.util.HashMap;
-import java.util.List;
-
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-
 import uk.co.oliwali.HawkEye.DataType;
 import uk.co.oliwali.HawkEye.util.InventoryUtil;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Represents a container transaction as created in {@MonitorInventoryListener}
@@ -37,8 +37,9 @@ public class ContainerEntry extends DataEntry {
 
 	@Override
 	public boolean rollback(Block block) {
-		if (!(block instanceof InventoryHolder)) return false;
-		Inventory inv = ((InventoryHolder) block.getState()).getInventory();
+		BlockState blockState = block.getState();
+		if (!(blockState instanceof InventoryHolder)) return false;
+		Inventory inv = ((InventoryHolder) blockState).getInventory();
 		List<HashMap<String,Integer>> ops = InventoryUtil.interpretDifferenceString(data);
 		//Handle the additions
 		if (ops.size() > 0) {
@@ -55,8 +56,9 @@ public class ContainerEntry extends DataEntry {
 
 	@Override
 	public boolean rebuild(Block block) {
-		if (!(block instanceof InventoryHolder)) return false;
-		Inventory inv = ((InventoryHolder) block.getState()).getInventory();
+		BlockState blockState = block.getState();
+		if (!(blockState instanceof InventoryHolder)) return false;
+		Inventory inv = ((InventoryHolder) blockState).getInventory();
 		List<HashMap<String,Integer>> ops = InventoryUtil.interpretDifferenceString(data);
 		//Handle the additions
 		if (ops.size() > 0) {


### PR DESCRIPTION
Fix Issue #105 where chest transactions's were not rolling back.

There are no implementation of a Block/InventoryHolder mix. You need to call block.getState() in order to get an object that impements it.
