### PR TITLE
Log hanging entities rather than only paintings.

### DIFF
--- a/src/main/java/uk/co/oliwali/HawkEye/DataType.java
+++ b/src/main/java/uk/co/oliwali/HawkEye/DataType.java
@@ -53,7 +53,9 @@ public enum DataType {
 	ENDERMAN_PLACE(33, BlockChangeEntry.class, "enderman-place", true, true),
     TREE_GROW(34, BlockChangeEntry.class, "tree-grow", true, true),
     MUSHROOM_GROW(35, BlockChangeEntry.class, "mushroom-grow", true, true),
-	ENTITY_KILL(36, DataEntry.class, "entity-kill", false, false);
+	ENTITY_KILL(36, DataEntry.class, "entity-kill", false, false),
+	HANGING_PLACE(37, DataEntry.class, "hanging-place", true, false),
+	HANGING_BREAK(38, DataEntry.class, "hanging-break", true, false);
 
 	private int id;
 	private boolean canHere;

--- a/src/main/java/uk/co/oliwali/HawkEye/listeners/MonitorEntityListener.java
+++ b/src/main/java/uk/co/oliwali/HawkEye/listeners/MonitorEntityListener.java
@@ -7,12 +7,17 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Enderman;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.hanging.HangingBreakByEntityEvent;
+import org.bukkit.event.hanging.HangingBreakEvent;
+import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.painting.PaintingBreakByEntityEvent;
 import org.bukkit.event.painting.PaintingBreakEvent;
 import org.bukkit.event.painting.PaintingBreakEvent.RemoveCause;
@@ -117,6 +122,16 @@ public class MonitorEntityListener extends HawkEyeListener {
 	@HawkEvent(dataType = DataType.PAINTING_PLACE)
 	public void onPaintingPlace(PaintingPlaceEvent event) {
 		DataManager.addEntry(new DataEntry(event.getPlayer(), DataType.PAINTING_PLACE, event.getPainting().getLocation(), ""));
+	}
+	
+	@HawkEvent(dataType = DataType.HANGING_PLACE)
+	public void onHangingPlace(HangingPlaceEvent event) {
+		DataManager.addEntry(new DataEntry(event.getPlayer(), DataType.HANGING_PLACE, event.getEntity().getLocation(), event.getEntity().getType().toString()));
+	}
+	
+	@HawkEvent(dataType = DataType.HANGING_BREAK)
+	public void onHangingBreak(HangingBreakByEntityEvent event) {
+		DataManager.addEntry(new DataEntry((Player)event.getRemover(), DataType.HANGING_BREAK, event.getEntity().getLocation(), event.getEntity().getType().toString()));
 	}
 
 	@HawkEvent(dataType = {DataType.ENDERMAN_PICKUP, DataType.ENDERMAN_PLACE})

--- a/src/main/java/uk/co/oliwali/HawkEye/util/Permission.java
+++ b/src/main/java/uk/co/oliwali/HawkEye/util/Permission.java
@@ -1,7 +1,6 @@
 package uk.co.oliwali.HawkEye.util;
-import com.nijiko.permissions.PermissionHandler;
-import com.nijikokun.bukkit.Permissions.Permissions;
 
+import org.bukkit.permissions.*;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
@@ -23,7 +22,6 @@ public class Permission {
 	private final HawkEye plugin;
 	private static PermissionPlugin handler = PermissionPlugin.BUKKITPERMS;
 	private static net.milkbowl.vault.permission.Permission vaultPermissions;
-	private static PermissionHandler permissionPlugin;
 	private static PermissionManager permissionsEx;
 
 	/**
@@ -51,11 +49,6 @@ public class Permission {
         	permissionsEx = PermissionsEx.getPermissionManager();
         	Util.info("Using PermissionsEx for user permissions");
 		}
-        else if (pm.isPluginEnabled("Permissions")) {
-        	permissionPlugin = ((Permissions)plugin.getServer().getPluginManager().getPlugin("Permissions")).getHandler();
-        	handler = PermissionPlugin.PERMISSIONS;
-        	Util.info("Using Permissions for user permissions");
-        }
         else {
         	Util.info("No permission handler detected, defaulting to superperms");
         }
@@ -79,8 +72,6 @@ public class Permission {
 				return vaultPermissions.has(player, node);
 			case PERMISSIONSEX:
 				return permissionsEx.has(player, node);
-			case PERMISSIONS:
-				return permissionPlugin.has(player, node);
 			case BUKKITPERMS:
 				return player.hasPermission(node);
 		}
@@ -202,8 +193,6 @@ public class Permission {
 				return vaultPermissions.playerInGroup(world, player, group);
 			case PERMISSIONSEX:
 				return permissionsEx.getUser(player).inGroup(group);
-			case PERMISSIONS:
-				return permissionPlugin.inGroup(world, player, group);
 		}
 		return false;
 	}


### PR DESCRIPTION
Log hanging entities (includes paintings and item frames) rather than only paintings.

Also remove Permissions, since it's dead and unsupported.
